### PR TITLE
Hotfix replace root mean square error in scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To use ArcSDM with ArcGIS Pro, follow these steps:
 
 3. **Restart ArcGIS Pro**:
     - Close and reopen ArcGIS Pro to apply the changes.
-    - Add Packages Scikit-learn (>=1.4), Tensorflow and Imbalanced-learn by searching those libraries:
+    - Add Packages Scikit-learn (1.30 <= x <= 1.5), Tensorflow and Imbalanced-learn by searching those libraries:
     ![Add Packages to ArcSDM Python Environment](./img/add_packages_arcsdm_py3_env.PNG)
     - Sometimes packages do not install due to Proxy settings. Please retry or contact your organizations IT Help to enable the installation.
 

--- a/Toolbox/arcsdm/evaluation/scoring.py
+++ b/Toolbox/arcsdm/evaluation/scoring.py
@@ -73,7 +73,7 @@ def _score_predictions(
     elif metric == "mse":
         score = mean_squared_error(y_true, y_pred)
     elif metric == "rmse":
-        score = root_mean_squared_error(y_true, y_pred)
+        score = mean_squared_error(y_true, y_pred, squared=False)
     elif metric == "r2":
         score = r2_score(y_true, y_pred)
     elif metric == "accuracy":

--- a/Toolbox/arcsdm/evaluation/scoring.py
+++ b/Toolbox/arcsdm/evaluation/scoring.py
@@ -16,7 +16,6 @@ from sklearn.metrics import (
     precision_score,
     r2_score,
     recall_score,
-    root_mean_squared_error,
 )
 
 


### PR DESCRIPTION
This is a hotfix of scoring.py that uses a sklearn version that some users cannot install.

Test PCA so that it runs successfully.